### PR TITLE
Add Reports Module with Maintenance and Order Reports sub-modules

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,8 @@ from config import Config
 from database.init_db import init_database
 from routes import (auth_bp, main_bp, spare_parts_bp, equipment_bp, location_bp,
                     work_orders_bp, maintenance_schedules_bp, meter_readings_bp,
-                    orders_bp, master_data_bp, vendors_bp, get_user_by_id)
+                    orders_bp, master_data_bp, vendors_bp, reports_bp,
+                    maintenance_reports_bp, order_reports_bp, get_user_by_id)
 
 app = Flask(__name__)
 app.config.from_object(Config)
@@ -32,6 +33,9 @@ app.register_blueprint(meter_readings_bp)
 app.register_blueprint(orders_bp)
 app.register_blueprint(master_data_bp)
 app.register_blueprint(vendors_bp)
+app.register_blueprint(reports_bp)
+app.register_blueprint(maintenance_reports_bp)
+app.register_blueprint(order_reports_bp)
 
 # Initialize database on startup
 with app.app_context():

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -9,3 +9,6 @@ from .meter_readings import meter_readings_bp
 from .orders import orders_bp
 from .master_data import master_data_bp
 from .vendors import vendors_bp
+from .reports import reports_bp
+from .maintenance_reports import maintenance_reports_bp
+from .order_reports import order_reports_bp

--- a/routes/main.py
+++ b/routes/main.py
@@ -173,11 +173,6 @@ def maintenance_schedule():
 def orders():
     return redirect(url_for('orders.index'))
 
-@main_bp.route('/reports')
-@login_required
-def reports():
-    return render_template('modules/reports.html', module_name='Reports')
-
 @main_bp.route('/organization')
 @login_required
 def organization():

--- a/routes/maintenance_reports.py
+++ b/routes/maintenance_reports.py
@@ -1,0 +1,11 @@
+from flask import Blueprint, render_template
+from flask_login import login_required
+
+maintenance_reports_bp = Blueprint('maintenance_reports', __name__, url_prefix='/reports/maintenance')
+
+
+@maintenance_reports_bp.route('/')
+@login_required
+def index():
+    """Maintenance Reports index page"""
+    return render_template('modules/reports/maintenance/index.html')

--- a/routes/order_reports.py
+++ b/routes/order_reports.py
@@ -1,0 +1,11 @@
+from flask import Blueprint, render_template
+from flask_login import login_required
+
+order_reports_bp = Blueprint('order_reports', __name__, url_prefix='/reports/orders')
+
+
+@order_reports_bp.route('/')
+@login_required
+def index():
+    """Order Reports index page"""
+    return render_template('modules/reports/orders/index.html')

--- a/routes/reports.py
+++ b/routes/reports.py
@@ -1,0 +1,11 @@
+from flask import Blueprint, render_template
+from flask_login import login_required
+
+reports_bp = Blueprint('reports', __name__, url_prefix='/reports')
+
+
+@reports_bp.route('/')
+@login_required
+def index():
+    """Reports module index page"""
+    return render_template('modules/reports/index.html')

--- a/templates/home.html
+++ b/templates/home.html
@@ -42,7 +42,7 @@
             <span class="module-label">Orders</span>
         </a>
 
-        <a href="{{ url_for('main.reports') }}" class="module-btn">
+        <a href="{{ url_for('reports.index') }}" class="module-btn">
             <span class="module-icon">&#128200;</span>
             <span class="module-label">Reports</span>
         </a>

--- a/templates/modules/reports/index.html
+++ b/templates/modules/reports/index.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block title %}Reports - Plant Maintenance{% endblock %}
+
+{% block content %}
+<div class="module-container">
+    <div class="module-header">
+        <a href="{{ url_for('main.home') }}" class="btn btn-back">
+            &#8592; Back to Home
+        </a>
+    </div>
+
+    <div class="module-content">
+        <span style="font-size: 4rem; margin-bottom: 1rem;">&#128202;</span>
+        <h1>Reports</h1>
+        <p class="description">View maintenance and order reports</p>
+
+        <div class="module-actions">
+            <a href="{{ url_for('maintenance_reports.index') }}" class="btn btn-module">
+                <span class="btn-icon">&#128295;</span>
+                <span class="btn-text">Maintenance Reports</span>
+            </a>
+            <a href="{{ url_for('order_reports.index') }}" class="btn btn-module">
+                <span class="btn-icon">&#128230;</span>
+                <span class="btn-text">Order Reports</span>
+            </a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/modules/reports/maintenance/index.html
+++ b/templates/modules/reports/maintenance/index.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block title %}Maintenance Reports - Plant Maintenance{% endblock %}
+
+{% block content %}
+<div class="module-container">
+    <div class="module-header">
+        <a href="{{ url_for('reports.index') }}" class="btn btn-back">
+            &#8592; Back to Reports
+        </a>
+    </div>
+
+    <div class="module-content">
+        <span style="font-size: 4rem; margin-bottom: 1rem;">&#128295;</span>
+        <h1>Maintenance Reports</h1>
+        <p class="description">View work order, schedule, and equipment maintenance reports</p>
+
+        <div class="module-actions">
+            <!-- Report types will be added here -->
+            <p style="text-align: center; color: #6b7280; margin-top: 2rem;">
+                Report types coming soon...
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/modules/reports/orders/index.html
+++ b/templates/modules/reports/orders/index.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block title %}Order Reports - Plant Maintenance{% endblock %}
+
+{% block content %}
+<div class="module-container">
+    <div class="module-header">
+        <a href="{{ url_for('reports.index') }}" class="btn btn-back">
+            &#8592; Back to Reports
+        </a>
+    </div>
+
+    <div class="module-content">
+        <span style="font-size: 4rem; margin-bottom: 1rem;">&#128230;</span>
+        <h1>Order Reports</h1>
+        <p class="description">View purchase order and inventory reports</p>
+
+        <div class="module-actions">
+            <!-- Report types will be added here -->
+            <p style="text-align: center; color: #6b7280; margin-top: 2rem;">
+                Report types coming soon...
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Create new Reports module structure accessible from home page with two sub-modules for organizing maintenance and order-related reports.

Changes:
- Create reports.py blueprint with /reports route
- Create maintenance_reports.py blueprint with /reports/maintenance route
- Create order_reports.py blueprint with /reports/orders route
- Add reports landing page with links to both sub-modules
- Add placeholder pages for Maintenance Reports and Order Reports
- Update app.py to register new blueprints
- Update routes/__init__.py to export new blueprints
- Remove old reports route from routes/main.py
- Update home.html to use new reports.index route