### PR TITLE
Add Financial/Spend Analysis report to Order Reports

### DIFF
--- a/routes/order_reports.py
+++ b/routes/order_reports.py
@@ -151,3 +151,107 @@ def delivery_performance():
                           period_label=period_label,
                           start_date=start_date.isoformat(),
                           end_date=end_date.isoformat())
+
+
+@order_reports_bp.route('/spend-analysis')
+@login_required
+def spend_analysis():
+    """Financial/Spend Analysis Report"""
+    conn = get_connection()
+    cursor = conn.cursor()
+
+    # Get date range from request parameters
+    period = request.args.get('period', 'last_30')
+    custom_start = request.args.get('start_date', '')
+    custom_end = request.args.get('end_date', '')
+
+    # Calculate date range
+    today = datetime.now().date()
+
+    if period == 'last_30':
+        start_date = today - timedelta(days=30)
+        end_date = today + timedelta(days=1)
+        period_label = 'Last 30 Days'
+    elif period == 'last_90':
+        start_date = today - timedelta(days=90)
+        end_date = today + timedelta(days=1)
+        period_label = 'Last 90 Days'
+    elif period == 'current_month':
+        start_date = today.replace(day=1)
+        end_date = today + timedelta(days=1)
+        period_label = 'Current Month'
+    elif period == 'custom' and custom_start and custom_end:
+        start_date = datetime.strptime(custom_start, '%Y-%m-%d').date()
+        end_date = datetime.strptime(custom_end, '%Y-%m-%d').date()
+        period_label = f'{start_date.strftime("%b %d, %Y")} - {end_date.strftime("%b %d, %Y")}'
+    else:
+        start_date = today - timedelta(days=30)
+        end_date = today + timedelta(days=1)
+        period_label = 'Last 30 Days'
+        period = 'last_30'
+
+    # Query POs in date range (exclude Cancelled)
+    cursor.execute('''
+        SELECT po.id, po.po_number, po.total_amount, po.order_date,
+               po.status, v.name as vendor_name, v.vendor_id
+        FROM purchase_orders po
+        LEFT JOIN vendors v ON po.vendor_id = v.id
+        WHERE DATE(po.order_date) BETWEEN ? AND ?
+        AND po.status != 'Cancelled'
+        ORDER BY po.order_date DESC
+    ''', (start_date.isoformat(), end_date.isoformat()))
+
+    purchase_orders = cursor.fetchall()
+
+    # Calculate overall summary metrics
+    total_spend = sum(po['total_amount'] for po in purchase_orders)
+    total_pos = len(purchase_orders)
+    avg_po_value = (total_spend / total_pos) if total_pos > 0 else 0
+
+    # Calculate spend by vendor
+    vendor_spend = {}
+    for po in purchase_orders:
+        vendor_name = po['vendor_name'] or 'Unknown Vendor'
+        if vendor_name not in vendor_spend:
+            vendor_spend[vendor_name] = {
+                'vendor_name': vendor_name,
+                'total_spend': 0,
+                'po_count': 0,
+                'po_numbers': []
+            }
+        vendor_spend[vendor_name]['total_spend'] += po['total_amount']
+        vendor_spend[vendor_name]['po_count'] += 1
+        vendor_spend[vendor_name]['po_numbers'].append(po['po_number'])
+
+    # Convert to list and calculate percentages and averages
+    vendor_data = []
+    for vendor_name, data in vendor_spend.items():
+        avg_vendor_po = data['total_spend'] / data['po_count']
+        percentage = (data['total_spend'] / total_spend * 100) if total_spend > 0 else 0
+
+        vendor_data.append({
+            'vendor_name': vendor_name,
+            'total_spend': round(data['total_spend'], 2),
+            'po_count': data['po_count'],
+            'avg_po_value': round(avg_vendor_po, 2),
+            'percentage': round(percentage, 1)
+        })
+
+    # Sort by total spend descending
+    vendor_data.sort(key=lambda x: x['total_spend'], reverse=True)
+
+    summary = {
+        'total_spend': round(total_spend, 2),
+        'total_pos': total_pos,
+        'avg_po_value': round(avg_po_value, 2)
+    }
+
+    conn.close()
+
+    return render_template('modules/reports/orders/spend_analysis.html',
+                          summary=summary,
+                          vendors=vendor_data,
+                          period=period,
+                          period_label=period_label,
+                          start_date=start_date.isoformat(),
+                          end_date=end_date.isoformat())

--- a/templates/modules/reports/orders/index.html
+++ b/templates/modules/reports/orders/index.html
@@ -20,6 +20,10 @@
                 <span class="btn-icon">&#128666;</span>
                 <span class="btn-text">PO Delivery Performance</span>
             </a>
+            <a href="{{ url_for('order_reports.spend_analysis') }}" class="btn btn-module">
+                <span class="btn-icon">&#128176;</span>
+                <span class="btn-text">Financial/Spend Analysis</span>
+            </a>
         </div>
     </div>
 </div>

--- a/templates/modules/reports/orders/spend_analysis.html
+++ b/templates/modules/reports/orders/spend_analysis.html
@@ -1,0 +1,357 @@
+{% extends "base.html" %}
+
+{% block title %}Financial/Spend Analysis - Plant Maintenance{% endblock %}
+
+{% block content %}
+<div class="report-container">
+    <!-- Header -->
+    <div class="report-header">
+        <a href="{{ url_for('order_reports.index') }}" class="btn btn-back">
+            &#8592; Back to Order Reports
+        </a>
+        <h1>Financial/Spend Analysis</h1>
+        <p class="report-subtitle">Purchase Order Spending Analysis by Vendor</p>
+    </div>
+
+    <!-- Date Range Selector -->
+    <div class="date-range-selector">
+        <form method="GET" action="{{ url_for('order_reports.spend_analysis') }}" id="periodForm">
+            <div class="period-options">
+                <label class="period-option">
+                    <input type="radio" name="period" value="last_30"
+                           {% if period == 'last_30' %}checked{% endif %}
+                           onchange="toggleCustomDates(false); document.getElementById('periodForm').submit();">
+                    <span>Last 30 Days</span>
+                </label>
+                <label class="period-option">
+                    <input type="radio" name="period" value="last_90"
+                           {% if period == 'last_90' %}checked{% endif %}
+                           onchange="toggleCustomDates(false); document.getElementById('periodForm').submit();">
+                    <span>Last 90 Days</span>
+                </label>
+                <label class="period-option">
+                    <input type="radio" name="period" value="current_month"
+                           {% if period == 'current_month' %}checked{% endif %}
+                           onchange="toggleCustomDates(false); document.getElementById('periodForm').submit();">
+                    <span>Current Month</span>
+                </label>
+                <label class="period-option">
+                    <input type="radio" name="period" value="custom"
+                           {% if period == 'custom' %}checked{% endif %}
+                           onchange="toggleCustomDates(true)">
+                    <span>Custom Range</span>
+                </label>
+            </div>
+            <div class="custom-date-inputs" id="customDates" style="{% if period != 'custom' %}display: none;{% endif %}">
+                <label>
+                    Start Date:
+                    <input type="date" name="start_date" value="{{ start_date }}" required>
+                </label>
+                <label>
+                    End Date:
+                    <input type="date" name="end_date" value="{{ end_date }}" required>
+                </label>
+                <button type="submit" class="btn btn-primary">Apply</button>
+            </div>
+        </form>
+        <div class="current-period">
+            <strong>Period:</strong> {{ period_label }}
+        </div>
+    </div>
+
+    <!-- Summary Statistics -->
+    <div class="summary-cards">
+        <div class="summary-card card-total">
+            <div class="card-label">Total Spend</div>
+            <div class="card-value">${{ "{:,.2f}".format(summary.total_spend) }}</div>
+            <div class="card-subtitle">All Orders</div>
+        </div>
+        <div class="summary-card card-info">
+            <div class="card-label">Average PO Value</div>
+            <div class="card-value">${{ "{:,.2f}".format(summary.avg_po_value) }}</div>
+            <div class="card-subtitle">Per Order</div>
+        </div>
+        <div class="summary-card card-success">
+            <div class="card-label">Total POs</div>
+            <div class="card-value">{{ summary.total_pos }}</div>
+            <div class="card-subtitle">Purchase Orders</div>
+        </div>
+    </div>
+
+    <!-- Vendor Spend Table -->
+    <div class="report-table-container">
+        <h2>Spend by Vendor</h2>
+        {% if vendors %}
+        <table class="report-table">
+            <thead>
+                <tr>
+                    <th>Vendor Name</th>
+                    <th class="numeric">Total Spend</th>
+                    <th class="numeric"># of POs</th>
+                    <th class="numeric">Avg PO Value</th>
+                    <th class="numeric">% of Total</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for vendor in vendors %}
+                <tr>
+                    <td class="vendor-name">{{ vendor.vendor_name }}</td>
+                    <td class="numeric currency">${{ "{:,.2f}".format(vendor.total_spend) }}</td>
+                    <td class="numeric">{{ vendor.po_count }}</td>
+                    <td class="numeric currency">${{ "{:,.2f}".format(vendor.avg_po_value) }}</td>
+                    <td class="numeric percentage">{{ vendor.percentage }}%</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <p class="no-data">No purchase orders found for the selected period.</p>
+        {% endif %}
+    </div>
+</div>
+
+<style>
+/* Report Container */
+.report-container {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 1.5rem;
+}
+
+/* Header */
+.report-header {
+    margin-bottom: 2rem;
+}
+
+.report-header h1 {
+    margin: 1rem 0 0.5rem 0;
+    color: var(--text-color);
+    font-size: 2rem;
+}
+
+.report-subtitle {
+    color: #6b7280;
+    font-size: 1rem;
+    margin: 0;
+}
+
+/* Date Range Selector */
+.date-range-selector {
+    background: white;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.period-options {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+}
+
+.period-option {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    border: 2px solid #e5e7eb;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.period-option:hover {
+    border-color: var(--primary);
+    background: #f0f9ff;
+}
+
+.period-option input[type="radio"] {
+    cursor: pointer;
+}
+
+.period-option input[type="radio"]:checked + span {
+    font-weight: 600;
+    color: var(--primary);
+}
+
+.custom-date-inputs {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-end;
+    padding-top: 1rem;
+    border-top: 1px solid #e5e7eb;
+}
+
+.custom-date-inputs label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.875rem;
+    color: #4b5563;
+}
+
+.custom-date-inputs input[type="date"] {
+    padding: 0.5rem;
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    font-size: 0.875rem;
+}
+
+.current-period {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid #e5e7eb;
+    font-size: 0.875rem;
+    color: #4b5563;
+}
+
+/* Summary Cards */
+.summary-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.summary-card {
+    background: white;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: 1.5rem;
+    text-align: center;
+    border-top: 4px solid;
+}
+
+.summary-card.card-total {
+    border-top-color: #3b82f6;
+}
+
+.summary-card.card-success {
+    border-top-color: #10b981;
+}
+
+.summary-card.card-info {
+    border-top-color: #6366f1;
+}
+
+.card-label {
+    font-size: 0.875rem;
+    color: #6b7280;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.5rem;
+}
+
+.card-value {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: var(--text-color);
+    line-height: 1;
+}
+
+.card-subtitle {
+    font-size: 0.875rem;
+    color: #6b7280;
+    margin-top: 0.5rem;
+}
+
+/* Report Table */
+.report-table-container {
+    background: white;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: 1.5rem;
+}
+
+.report-table-container h2 {
+    margin: 0 0 1rem 0;
+    font-size: 1.25rem;
+    color: var(--text-color);
+}
+
+.report-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+}
+
+.report-table thead {
+    background: #f9fafb;
+    border-bottom: 2px solid #e5e7eb;
+}
+
+.report-table th {
+    text-align: left;
+    padding: 0.75rem 0.5rem;
+    font-weight: 600;
+    color: #374151;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+    white-space: nowrap;
+}
+
+.report-table th.numeric {
+    text-align: right;
+}
+
+.report-table tbody tr {
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.report-table tbody tr:hover {
+    background: #f9fafb;
+}
+
+.report-table tbody tr:last-child {
+    border-bottom: none;
+}
+
+.report-table td {
+    padding: 0.75rem 0.5rem;
+    color: #1f2937;
+}
+
+.report-table td.numeric {
+    text-align: right;
+    font-weight: 500;
+}
+
+.report-table td.currency {
+    font-family: 'Courier New', monospace;
+}
+
+.report-table td.percentage {
+    color: #059669;
+    font-weight: 600;
+}
+
+.vendor-name {
+    font-weight: 500;
+    max-width: 300px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.no-data {
+    text-align: center;
+    color: #6b7280;
+    padding: 2rem;
+    font-style: italic;
+}
+</style>
+
+<script>
+function toggleCustomDates(show) {
+    const customDates = document.getElementById('customDates');
+    if (show) {
+        customDates.style.display = 'flex';
+    } else {
+        customDates.style.display = 'none';
+    }
+}
+</script>
+{% endblock %}


### PR DESCRIPTION
Create professional spend analysis report for supervisors to track procurement spending patterns by vendor and time period with Excel-style formatting.

Features:
- Summary KPI cards: Total Spend, Average PO Value, Total POs
- Vendor breakdown table with spend metrics per vendor
- Date range filtering (Last 30/90 days, Current Month, Custom)
- Exclude Cancelled POs from calculations
- Sort vendors by total spend (highest first)

KPIs Displayed:
- Total Spend: Sum of all PO total_amount in period
- Average PO Value: Total spend divided by number of POs
- Total POs: Count of purchase orders in period

Vendor Table Columns:
- Vendor Name
- Total Spend (currency formatted with commas and 2 decimals)
- Number of POs
- Average PO Value per vendor
- Percentage of Total Spend

Technical Implementation:
- Filter by order_date (not created_at) for accurate financial reporting
- Exclude status='Cancelled' POs from spend calculations
- Group spending by vendor with aggregation
- Calculate vendor-level averages and percentages
- Currency formatting: ${:,.2f} with right-aligned numeric columns
- Professional Excel-like table styling with hover effects
- Timezone handling with +1 day buffer

Route: /reports/orders/spend-analysis
Template: templates/modules/reports/orders/spend_analysis.html